### PR TITLE
Add initial Qodana configuration for code analysis

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,54 @@
+#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+
+#################################################################################
+#              WARNING: Do not store sensitive information in this file,        #
+#               as its contents will be included in the Qodana report.          #
+#################################################################################
+version: "1.0"
+
+#Specify inspection profile for code analysis
+profile:
+  name: qodana.starter
+
+#Enable inspections
+#include:
+#  - name: <SomeEnabledInspectionId>
+
+#Disable inspections
+#exclude:
+#  - name: <SomeDisabledInspectionId>
+#    paths:
+#      - <path/where/not/run/inspection>
+
+projectJDK: "25" #(Applied in CI/CD pipeline)
+
+#Execute shell command before Qodana execution (Applied in CI/CD pipeline)
+#bootstrap: sh ./prepare-qodana.sh
+
+#Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
+#plugins:
+#  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
+
+# Quality gate. Will fail the CI/CD pipeline if any condition is not met
+# severityThresholds - configures maximum thresholds for different problem severities
+# testCoverageThresholds - configures minimum code coverage on a whole project and newly added code
+# Code Coverage is available in Ultimate and Ultimate Plus plans
+#failureConditions:
+#  severityThresholds:
+#    any: 15
+#    critical: 5
+#  testCoverageThresholds:
+#    fresh: 70
+#    total: 50
+
+#Specify Qodana linter for analysis (Applied in CI/CD pipeline)
+linter: jetbrains/qodana-jvm:2026.1
+
+testCoverageThresholds:
+  fresh: 70
+  total: 50
+
+raiseLicenseProblems: true


### PR DESCRIPTION
This pull request introduces a new Qodana configuration file to the repository. The `qodana.yaml` file defines code analysis settings, specifies the inspection profile, sets minimum code coverage thresholds, and configures the linter and JDK version for Qodana static analysis.

Qodana configuration:

* Added a new `qodana.yaml` file to configure Qodana static code analysis, including the inspection profile (`qodana.starter`), minimum code coverage thresholds (`fresh: 70`, `total: 50`), linter image (`jetbrains/qodana-jvm:2026.1`), and project JDK version (`25`).